### PR TITLE
Use golang template functions to remove spaces; resolve cosmetic issues

### DIFF
--- a/layouts/_partials/image-grid.html
+++ b/layouts/_partials/image-grid.html
@@ -28,47 +28,47 @@
           >
             <picture>
               {{/* the following safely dereferences the pointers to multiple resources objects in the given bundle */}}
-              {{ with $small := index $resources "400" }}
-                {{ with $medium := index $resources "800" }}
+              {{- with $small := index $resources "400" -}}
+                {{- with $medium := index $resources "800" -}}
                   <source
-                    type="{{ $medium.MediaType.Type }}"
+                    type="{{- $medium.MediaType.Type -}}"
                     media="(width <= 1024px)"
-                    srcset="{{ $medium.RelPermalink }}"
+                    srcset="{{- $medium.RelPermalink -}}"
                   />
                   <source
-                    type="{{ $small.MediaType.Type }}"
+                    type="{{- $small.MediaType.Type -}}"
                     media="(width > 1024px)"
-                    srcset="{{ $small.RelPermalink }}"
+                    srcset="{{- $small.RelPermalink -}}"
                   />
-                {{ else }}
+                {{- else -}}
                   <source
-                    type="{{ $small.MediaType.Type }}"
+                    type="{{- $small.MediaType.Type -}}"
                     media="(width > 1024px)"
-                    srcset="{{ $small.RelPermalink }}"
+                    srcset="{{- $small.RelPermalink -}}"
                   />
-                {{ end }}
-              {{ else }}
-                {{ with $medium := index $resources "800w" }}
+                {{- end -}}
+              {{- else -}}
+                {{- with $medium := index $resources "800w" -}}
                   <source
-                    type="{{ $medium.MediaType.Type }}"
+                    type="{{- $medium.MediaType.Type -}}"
                     media="(width <= 1024px)"
-                    srcset="{{ $medium.RelPermalink }}"
+                    srcset="{{- $medium.RelPermalink -}}"
                   />
-                {{ end }}
-              {{ end }}
+                {{- end -}}
+              {{- end -}}
               <source
-                type="{{ $original.MediaType.Type }}"
-                srcset="{{ $original.RelPermalink }}"
+                type="{{- $original.MediaType.Type -}}"
+                srcset="{{- $original.RelPermalink -}}"
               />
               {{/* Alternate fallback format: single original, no size-aware srcset */}}
-              {{ $imgSrc := $originalLink }}
-              {{ with $alt := index $resources "alt" }}
-                {{ $imgSrc = $alt.RelPermalink }}
-              {{ end }}
+              {{- $imgSrc := $originalLink -}}
+              {{- with $alt := index $resources "alt" -}}
+                {{- $imgSrc = $alt.RelPermalink -}}
+              {{- end -}}
               <img
                 loading="lazy"
-                src="{{ $imgSrc }}"
-                alt="{{ $original.Name }}"
+                src="{{- $imgSrc -}}"
+                alt="{{- $original.Name -}}"
               />
             </picture>
           </a>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,17 +1,17 @@
 {{- define "main" -}}
   {{- with .Content -}}
-    <div class="content">{{ . }}</div>
+    <div class="content">{{- . -}}</div>
   {{- end -}}
 
   {{- $useFeatured := partialCached "use-featured-images.html" . -}}
 
   {{/* Home root images */}}
   {{- if .Resources.ByType "image" -}}
-  {{- $rootItems := partial "prepare-bundle-images.html" . -}}
-  <section class="gallery-section">
-    <h2 class="section-title">Non-Gallery Photos</h2>
-    {{- partial "image-grid.html" $rootItems -}}
-  </section>
+    {{- $rootItems := partial "prepare-bundle-images.html" . -}}
+    <section class="gallery-section">
+      <h2 class="section-title">Home Photos</h2>
+      {{- partial "image-grid.html" $rootItems -}}
+    </section>
   {{- end -}}
   {{/* Immediate child galleries: direct subsections + direct regular pages */}}
   {{- if $useFeatured -}}
@@ -23,7 +23,9 @@
     </section>
   {{- else -}}
     {{- $rootChildren := slice -}}
-    {{- range .Sections -}}{{ $rootChildren = $rootChildren | append . }}{{ end }}
+    {{- range .Sections -}}
+      {{- $rootChildren = $rootChildren | append . }}
+    {{ end }}
     {{- range .RegularPages -}}
       {{- $rootChildren = $rootChildren | append . -}}
     {{- end -}}
@@ -31,7 +33,7 @@
     {{- range $rootChildren -}}
       <section class="gallery-section">
         <h2 class="section-title">
-          <a href="{{- .RelPermalink -}}">{{ .Title }}</a>
+          <a href="{{- .RelPermalink -}}">{{- .Title -}}</a>
         </h2>
         {{- $items := partial "prepare-bundle-images.html" . -}}
         {{- partial "image-grid.html" $items -}}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,40 +1,41 @@
-{{ define "main" }}
-  {{ with .Content }}
+{{- define "main" -}}
+  {{- with .Content -}}
     <div class="content">{{ . }}</div>
-  {{ end }}
+  {{- end -}}
 
-  {{ $useFeatured := partialCached "use-featured-images.html" . }}
+  {{- $useFeatured := partialCached "use-featured-images.html" . -}}
 
   {{/* Home root images */}}
-  {{ $rootItems := partial "prepare-bundle-images.html" . }}
+  {{- if .Resources.ByType "image" -}}
+  {{- $rootItems := partial "prepare-bundle-images.html" . -}}
   <section class="gallery-section">
     <h2 class="section-title">Non-Gallery Photos</h2>
-    {{ partial "image-grid.html" $rootItems }}
+    {{- partial "image-grid.html" $rootItems -}}
   </section>
-
+  {{- end -}}
   {{/* Immediate child galleries: direct subsections + direct regular pages */}}
-  {{ if $useFeatured }}
+  {{- if $useFeatured -}}
     {{/* When using featured images, show child galleries as a single grid */}}
-    {{ $galleryItems := partial "prepare-children-featured-items.html" . }}
+    {{- $galleryItems := partial "prepare-children-featured-items.html" . -}}
     <section class="gallery-section">
       <h2 class="section-title">Galleries</h2>
-      {{ partial "image-grid.html" $galleryItems }}
+      {{- partial "image-grid.html" $galleryItems -}}
     </section>
-  {{ else }}
-    {{ $rootChildren := slice }}
-    {{ range .Sections }}{{ $rootChildren = $rootChildren | append . }}{{ end }}
-    {{ range .RegularPages }}
-      {{ $rootChildren = $rootChildren | append . }}
-    {{ end }}
+  {{- else -}}
+    {{- $rootChildren := slice -}}
+    {{- range .Sections -}}{{ $rootChildren = $rootChildren | append . }}{{ end }}
+    {{- range .RegularPages -}}
+      {{- $rootChildren = $rootChildren | append . -}}
+    {{- end -}}
 
-    {{ range $rootChildren }}
+    {{- range $rootChildren -}}
       <section class="gallery-section">
         <h2 class="section-title">
-          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+          <a href="{{- .RelPermalink -}}">{{ .Title }}</a>
         </h2>
-        {{ $items := partial "prepare-bundle-images.html" . }}
-        {{ partial "image-grid.html" $items }}
+        {{- $items := partial "prepare-bundle-images.html" . -}}
+        {{- partial "image-grid.html" $items -}}
       </section>
-    {{ end }}
-  {{ end }}
-{{ end }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -1,36 +1,33 @@
-{{ define "main" }}
-  {{ with .Title }}<h1 class="page-title">{{ . }}</h1>{{ end }}
-  {{ with .Content }}<div class="content">{{ . }}</div>{{ end }}
-  {{ $useFeatured := partialCached "use-featured-images.html" . }}
+{{- define "main" -}}
+  {{- with .Title -}}<h1 class="page-title">{{- . -}}</h1>{{- end -}}
+  {{- with .Content -}}<div class="content">{{- . -}}</div>{{- end -}}
+  {{- $useFeatured := partialCached "use-featured-images.html" . -}}
 
-
-  <section>
-    {{ $items := partial "prepare-bundle-images.html" . }}
-    {{ partial "image-grid.html" $items }}
+  <section class="gallery-section">
+    {{- $items := partial "prepare-bundle-images.html" . -}}
+    {{- partial "image-grid.html" $items -}}
   </section>
 
-  {{/* Immediate child galleries: direct subsections + direct regular pages */}}
-  {{ if $useFeatured }}
-    {{/* When using featured images, show child galleries as a single grid */}}
-    {{ $galleryItems := partial "prepare-children-featured-items.html" . }}
+  {{- if $useFeatured -}}
+    {{- $galleryItems := partial "prepare-children-featured-items.html" . -}}
     <section class="gallery-section">
       <h2 class="section-title">Galleries</h2>
-      {{ partial "image-grid.html" $galleryItems }}
+      {{- partial "image-grid.html" $galleryItems -}}
     </section>
-  {{ else }}
-    {{ $children := slice }}
-    {{ range .Sections }}{{ $children = $children | append . }}{{ end }}
-    {{ range .RegularPages }}{{ $children = $children | append . }}{{ end }}
+  {{- else -}}
+    {{- $children := slice -}}
+    {{- range .Sections -}}{{ $children = $children | append . -}}{{- end -}}
+    {{- range .RegularPages -}}{{ $children = $children | append . -}}{{- end -}}
 
-    {{ range $children }}
+    {{- range $children -}}
       <section class="gallery-section">
         <h2 class="section-title">
-          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+          <a href="{{- .RelPermalink -}}">{{- .Title -}}</a>
         </h2>
-        {{ $items := partial "prepare-bundle-images.html" . }}
-        {{ partial "image-grid.html" $items }}
+        {{- $items := partial "prepare-bundle-images.html" . -}}
+        {{- partial "image-grid.html" $items -}}
       </section>
-    {{ end }}
-  {{ end }}
+    {{- end -}}
+  {{- end -}}
 
-{{ end }}
+{{- end -}}

--- a/layouts/list.html
+++ b/layouts/list.html
@@ -3,6 +3,7 @@
   {{- with .Content -}}<div class="content">{{- . -}}</div>{{- end -}}
   {{- $useFeatured := partialCached "use-featured-images.html" . -}}
 
+
   <section class="gallery-section">
     {{- $items := partial "prepare-bundle-images.html" . -}}
     {{- partial "image-grid.html" $items -}}
@@ -17,7 +18,9 @@
   {{- else -}}
     {{- $children := slice -}}
     {{- range .Sections -}}{{ $children = $children | append . -}}{{- end -}}
-    {{- range .RegularPages -}}{{ $children = $children | append . -}}{{- end -}}
+    {{- range .RegularPages -}}
+      {{ $children = $children | append . -}}
+    {{- end -}}
 
     {{- range $children -}}
       <section class="gallery-section">

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -3,6 +3,7 @@
 
   {{- with .Content -}}<div class="content">{{- . -}}</div>{{- end -}}
 
+
   <section class="gallery-section">
     {{- $items := partial "prepare-bundle-images.html" . -}}
     {{- partial "image-grid.html" $items -}}

--- a/layouts/single.html
+++ b/layouts/single.html
@@ -1,8 +1,10 @@
-{{ define "main" }}
-  {{ with .Title }}<h1 class="page-title">{{ . }}</h1>{{ end }}
+{{- define "main" -}}
+  {{- with .Title -}}<h1 class="page-title">{{- . -}}</h1>{{- end -}}
 
-  {{ with .Content }}<div class="content">{{ . }}</div>{{ end }}
+  {{- with .Content -}}<div class="content">{{- . -}}</div>{{- end -}}
 
-  {{ $items := partial "prepare-bundle-images.html" . }}
-  {{ partial "image-grid.html" $items }}
-{{ end }}
+  <section class="gallery-section">
+    {{- $items := partial "prepare-bundle-images.html" . -}}
+    {{- partial "image-grid.html" $items -}}
+  </section>
+{{- end -}}


### PR DESCRIPTION
- Changes "non gallery images" --> "Home images". This section on the home page is now only shown if there are images present in the root content folder.
- Liberally use golang templates `{{- -}}` to remove generated whitespace and line breaks in template outputs
- Ensure page and list bundle images are displayed within a HTML `<section>` tag with the `gallery-section` class